### PR TITLE
Add named exports of CSS, JS and SVG dist files to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
   "main": "dist/js/dkfds.min.js",
   "exports": {
     ".": "./dist/js/dkfds.min.js",
-    "./dkfds-DEPRECATED": "./dist/DEPRECATED/dkfds-DEPRECATED.min.js"
+    "./dkfds-DEPRECATED": "./dist/DEPRECATED/dkfds-DEPRECATED.min.js",
+    "./dkfds.min.css": "./dist/css/dkfds.min.css",
+    "./dkfds.min.js": "./dist/js/dkfds.min.js",
+    "./all-svg-icons.svg": "./dist/img/all-svg-icons.svg"
   },
   "scripts": {
     "build": "webpack"


### PR DESCRIPTION
This allows them to be imported using e.g. `import css from "dkfds/dkfds.min.css"` in modern frontend frameworks.