### PR TITLE
Add named exports of CSS, JS and SVG dist files to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     ".": "./dist/js/dkfds.min.js",
     "./dkfds-DEPRECATED": "./dist/DEPRECATED/dkfds-DEPRECATED.min.js",
     "./dkfds.min.css": "./dist/css/dkfds.min.css",
-    "./dkfds.min.js": "./dist/js/dkfds.min.js"
+    "./dkfds.min.js": "./dist/js/dkfds.min.js",
+    "./all-svg-icons.svg": "./dist/img/all-svg-icons.svg"
   },
   "scripts": {
     "build": "webpack"


### PR DESCRIPTION
This allows them to be imported using e.g. `import css from "dkfds/dkfds.min.css"` in modern frontend frameworks.